### PR TITLE
Fix for pypi package

### DIFF
--- a/lang-runners/python/stdlib/setup.py
+++ b/lang-runners/python/stdlib/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="robot-rumble-stdlib",
-    version="0.1.0",
+    version="0.1.1",
     license="GNU GPL3",
     author="Robot Rumble Team",
     author_email="antonoutkine@gmail.com",

--- a/lang-runners/python/stdlib/setup.py
+++ b/lang-runners/python/stdlib/setup.py
@@ -15,5 +15,5 @@ setup(
     project_urls={
         "Documentation": "https://rr-docs.readthedocs.io/en/latest/api.html",
     },
-    py_modules = ["rumblelib",],
+    py_modules=["rumblelib",],
 )

--- a/lang-runners/python/stdlib/setup.py
+++ b/lang-runners/python/stdlib/setup.py
@@ -15,4 +15,5 @@ setup(
     project_urls={
         "Documentation": "https://rr-docs.readthedocs.io/en/latest/api.html",
     },
+    py_modules = ["rumblelib",],
 )


### PR DESCRIPTION
Currently, installing the package `robot-rumble-stdlib` from pypi does not actually provide the module `rumblelib`.
I explicitly added the module in the setup.py and bumped the version to 0.1.1.

I did test this adding the package to pypi under a different name and it works as intended